### PR TITLE
Matrix re ordering

### DIFF
--- a/src/GPUGraphsMatrix.jl
+++ b/src/GPUGraphsMatrix.jl
@@ -308,7 +308,8 @@ function SparseGPUMatrixSELL(
     nnz_per_row = diff(rowptr)
 
     # Compute optimal permutation of rows to minimize padding (not implemented yet)
-    perm = reverse!(sortperm(nnz_per_row[:]))
+    #perm = reverse!(sortperm(nnz_per_row[:]))
+    perm = collect(1:size(m_t, 2))
     nnz_per_row = nnz_per_row[perm]
 
     # Compute the maximum number of nonzeros per row for each slice

--- a/src/algorithms/shortest_path.jl
+++ b/src/algorithms/shortest_path.jl
@@ -57,6 +57,7 @@ function shortest_path!(
     while true
 
         iter += one(Ti)
+        
         gpu_spmv!(
             next,
             A_T,
@@ -67,10 +68,13 @@ function shortest_path!(
             #mask = updated, Not used yet
         )
         # Diff : where we made progress
-        @. diff = next < dist
-        if reduce(|, diff) == zero(Td)
-            return nothing
+        if iter%8 == 0
+            @. diff = next < dist
+            if reduce(|, diff) == zero(Td)
+                return nothing
+            end
         end
+        
         # Update the dist array
         dist .= next
 

--- a/src/spmv.jl
+++ b/src/spmv.jl
@@ -340,15 +340,18 @@ end
     add,
     accum,
 )
+    #slice, offset = @index(Global, NTuple)
+    #offset = offset - 1
+    #row = (slice-1) * slice_size + offset + 1
     row = @index(Global, Linear)
-    if mask[row] != mask_zero
-        slice = (row-1) ÷ slice_size + 1
-        offset = (row-1) % slice_size
+    slice = (row-1) ÷ slice_size + 1
+    offset = (row-1) % slice_size
+    if row <= n && mask[row] != mask_zero
 
         acc = monoid_neutral_element
         for i = (a_slice_ptr[slice]+offset):slice_size:(a_slice_ptr[slice+1]-1)
             col = a_col_val[i]
-            if col == -1
+            if col == -1 || 
                 break
             end
             acc = add(acc, mul(a_nz_val[i], b[col], row, col, col, 1), row, col, col, 1)

--- a/src/spmv.jl
+++ b/src/spmv.jl
@@ -351,7 +351,7 @@ end
         acc = monoid_neutral_element
         for i = (a_slice_ptr[slice]+offset):slice_size:(a_slice_ptr[slice+1]-1)
             col = a_col_val[i]
-            if col == -1 || 
+            if col == -1 
                 break
             end
             acc = add(acc, mul(a_nz_val[i], b[col], row, col, col, 1), row, col, col, 1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,9 +41,9 @@ const PAD_VAL = -1
 
 
 
-    #include("structs.jl")
-    #include("spmv.jl")
-    #include("spmm.jl")
-    #include("bfs.jl")
+    include("structs.jl")
+    include("spmv.jl")
+    include("spmm.jl")
+    include("bfs.jl")
     include("shortest_path.jl")
 end


### PR DESCRIPTION
Re-ordering rows of SELL matrix to cluster rows with similar amount of non-zeros. This has the benefit of :
- Reducing padding 
- Reducing thread divergence during spmm/spmv

Currently implemented but disabled (proper support coming one day maybe)